### PR TITLE
Change hash_password to match django hash string

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This was originally built to import password hashes from django application to r
 
 ## Installation
 
-In your Gemfile : 
+In your Gemfile :
 ```ruby
 gem pbkdf2_password_hasher, git: 'aherve/pbkdf2-password-hasher'
 ```
@@ -25,13 +25,13 @@ salt = 'NaCl'    # random salt key
 pass = 's3cr3t'  # your password
 it   = 1000      # number of iterations
 
-hash = Pbkdf2PasswordHasher.hash_password(pass,salt,it)
+hash = Pbkdf2PasswordHasher.hash_password(pass,salt,it) #=> "pbkdf2_sha256$1000$NaCl$uDAu+fkRHoZk03PKp0bzrXDWc4j4mhkzGBm7ljbvp58="
 ```
 - Check password validity against string
 
 ```ruby
 # hashed string from django app
-hsh ='pbkdf2_sha256$12000$PEnXGf9dviXF$2soDhu1WB8NSbFDm0w6NEe6OvslVXtiyf4VMiiy9rH0=' 
+hsh ='pbkdf2_sha256$12000$PEnXGf9dviXF$2soDhu1WB8NSbFDm0w6NEe6OvslVXtiyf4VMiiy9rH0='
 
 # with right password:
 Pbkdf2PasswordHasher.check_password('bite',hsh) #=> true

--- a/lib/pbkdf2_password_hasher.rb
+++ b/lib/pbkdf2_password_hasher.rb
@@ -1,26 +1,22 @@
-require "pbkdf2_password_hasher/version"
+require 'pbkdf2_password_hasher/version'
 require 'pbkdf2_password_hasher/django_hash'
 
 module Pbkdf2PasswordHasher
-
   class << self
-
     # compute a hash from password, salt, number of iterations, and key length
-    def hash_password(pass,salt,nb_of_iterations,key_length=32)
-      DjangoHash.new(
+    def hash_password(pass, salt, nb_of_iterations, key_length = 32)
+      hsh = DjangoHash.new(
         :password => pass,
         :salt     => salt,
         :c        => nb_of_iterations,
-        :dklen    => key_length,
+        :dklen    => key_length
       ).get_hash
+      "pbkdf2_sha256$#{nb_of_iterations}$#{salt}$#{hsh}"
     end
 
     # Check password against hash string
-    def check_password(pass,hash)
-      DjangoHash::parse(hash).check_password(pass)
+    def check_password(pass, hash)
+      DjangoHash.parse(hash).check_password(pass)
     end
-
   end
-
 end
-

--- a/lib/pbkdf2_password_hasher/version.rb
+++ b/lib/pbkdf2_password_hasher/version.rb
@@ -1,3 +1,3 @@
 module Pbkdf2PasswordHasher
-  VERSION = "0.1.0"
+  VERSION = '0.2.0'
 end

--- a/spec/pbkdf2_password_hasher_spec.rb
+++ b/spec/pbkdf2_password_hasher_spec.rb
@@ -1,33 +1,27 @@
 require 'spec_helper'
-describe Pbkdf2PasswordHasher do 
-
-  before(:all) do 
+describe Pbkdf2PasswordHasher do
+  before(:all) do
     @django_hash = 'pbkdf2_sha256$12000$PEnXGf9dviXF$2soDhu1WB8NSbFDm0w6NEe6OvslVXtiyf4VMiiy9rH0='
   end
 
-  describe 'check_password' do 
-
-    describe "when provided the right password" do 
-      it "should validate" do 
-        Pbkdf2PasswordHasher::check_password('bite',@django_hash).should be_true
+  describe 'check_password' do
+    describe 'when provided the right password' do
+      it 'should validate' do
+        expect(Pbkdf2PasswordHasher.check_password('bite', @django_hash)).to be true
       end
     end
 
-    describe "when NOT provided the right password" do 
-      it "should NOT validate" do 
-        Pbkdf2PasswordHasher::check_password('false_pass',@django_hash).should be_false
+    describe 'when NOT provided the right password' do
+      it 'should NOT validate' do
+        expect(Pbkdf2PasswordHasher.check_password('false_pass', @django_hash)).to be false
       end
     end
-
   end
 
-  describe "hash_password" do 
-
-    it "should work" do 
-      a = @django_hash.split("$")
-      Pbkdf2PasswordHasher.hash_password('bite',a[2],a[1]).should == a[3]
+  describe 'hash_password' do
+    it 'should work' do
+      a = @django_hash.split('$')
+      expect(Pbkdf2PasswordHasher.hash_password('bite', a[2], a[1])).to eq(@django_hash)
     end
-
   end
-
 end


### PR DESCRIPTION
I changed hash_password output to include algo, salt, iteration.
Making it match with django hash format.

From the example in README:

``` ruby
Pbkdf2PasswordHasher.hash_password(pass,salt,it) #=> "uDAu+fkRHoZk03PKp0bzrXDWc4j4mhkzGBm7ljbvp58="
```

Pbkdf2PasswordHasher.hash_password(pass,salt,it) returning `uDAu+fkRHoZk03PKp0bzrXDWc4j4mhkzGBm7ljbvp58=` which is not the one check_password take in.

I changed it to

``` ruby
Pbkdf2PasswordHasher.hash_password(pass,salt,it) #=> "pbkdf2_sha256$1000$NaCl$uDAu+fkRHoZk03PKp0bzrXDWc4j4mhkzGBm7ljbvp58="
```

I have updated the spec and README as well.

Lincoln
